### PR TITLE
expenses: add expense with equal split + list group expenses (closes #6)

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import healthRouter from "./routes/health";
 import authRouter from "./routes/auth";
 import groupsRouter from "./routes/groups";
+import expensesRouter from "./routes/expenses";
 
 const app = express();
 
@@ -14,5 +15,6 @@ app.use(express.json());
 app.use("/api/health", healthRouter);
 app.use("/api/auth", authRouter);
 app.use("/api/groups", groupsRouter);
+app.use("/api/expenses", expensesRouter);
 
 export default app;

--- a/server/src/controllers/expenseController.ts
+++ b/server/src/controllers/expenseController.ts
@@ -1,0 +1,116 @@
+import { Response } from "express";
+import { AuthRequest } from "../middleware/auth";
+import prisma from "../utils/prisma";
+import { Prisma } from "@prisma/client";
+
+// POST /api/expenses
+export const addExpense = async (
+  req: AuthRequest,
+  res: Response
+): Promise<void> => {
+  const { group_id, amount, description } = req.body;
+  const payerId = req.userId!;
+
+  if (!group_id || !amount || !description) {
+    res.status(400).json({ error: "group_id, amount, and description are required" });
+    return;
+  }
+
+  if (Number(amount) <= 0) {
+    res.status(400).json({ error: "Amount must be greater than zero" });
+    return;
+  }
+
+  try {
+    // Verify payer is a member of the group
+    const membership = await prisma.groupMember.findUnique({
+      where: { group_id_user_id: { group_id, user_id: payerId } },
+    });
+
+    if (!membership) {
+      res.status(403).json({ error: "You are not a member of this group" });
+      return;
+    }
+
+    // Get all group members for equal split
+    const members = await prisma.groupMember.findMany({
+      where: { group_id },
+    });
+
+    const total = new Prisma.Decimal(amount);
+    const memberCount = members.length;
+    const splitAmount = total.dividedBy(memberCount).toDecimalPlaces(2);
+
+    // Create expense and splits in a transaction
+    const expense = await prisma.$transaction(async (tx) => {
+      const newExpense = await tx.expense.create({
+        data: {
+          group_id,
+          payer_id: payerId,
+          amount: total,
+          description,
+        },
+      });
+
+      await tx.expenseSplit.createMany({
+        data: members.map((m) => ({
+          expense_id: newExpense.id,
+          user_id: m.user_id,
+          amount_owed: splitAmount,
+        })),
+      });
+
+      return tx.expense.findUnique({
+        where: { id: newExpense.id },
+        include: {
+          payer: { select: { id: true, name: true, email: true } },
+          splits: {
+            include: { user: { select: { id: true, name: true, email: true } } },
+          },
+        },
+      });
+    });
+
+    res.status(201).json(expense);
+  } catch (error) {
+    console.error("Add expense error:", error);
+    res.status(500).json({ error: "Failed to add expense" });
+  }
+};
+
+// GET /api/expenses/:groupId
+export const getGroupExpenses = async (
+  req: AuthRequest,
+  res: Response
+): Promise<void> => {
+  const groupId = req.params.groupId as string;
+  const userId = req.userId!;
+
+  try {
+    // Verify user is a member
+    const membership = await prisma.groupMember.findUnique({
+      where: { group_id_user_id: { group_id: groupId, user_id: userId } },
+    });
+
+    if (!membership) {
+      res.status(403).json({ error: "You are not a member of this group" });
+      return;
+    }
+
+    const expenses = await prisma.expense.findMany({
+      where: { group_id: groupId },
+      include: {
+        payer: { select: { id: true, name: true, email: true } },
+        splits: {
+          include: { user: { select: { id: true, name: true, email: true } } },
+        },
+      },
+      orderBy: { created_at: "desc" },
+    });
+
+    res.json(expenses);
+  } catch (error) {
+    console.error("Get expenses error:", error);
+    res.status(500).json({ error: "Failed to fetch expenses" });
+  }
+};

--- a/server/src/routes/expenses.ts
+++ b/server/src/routes/expenses.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth";
+import { addExpense, getGroupExpenses } from "../controllers/expenseController";
+
+const router = Router();
+
+router.use(authenticate);
+
+router.post("/", addExpense);
+router.get("/:groupId", getGroupExpenses);
+
+export default router;


### PR DESCRIPTION
Implements expense management with equal splitting across all group members:

POST /api/expenses — Add an expense to a group. Automatically splits the amount equally among all group members. Validates that the payer is a group member.
GET /api/expenses/:groupId — List all expenses for a group (with payer info and split details), ordered by most recent first.
Both endpoints are protected by JWT authentication. The split calculation uses Prisma.Decimal for precise currency math, and expense + splits are created atomically in a transaction.

Files changed:

[expenseController.ts](vscode-file://vscode-app/c:/Users/tanuj/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Expense business logic with equal split
[expenses.ts](vscode-file://vscode-app/c:/Users/tanuj/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Route definitions with auth middleware
[app.ts](vscode-file://vscode-app/c:/Users/tanuj/AppData/Local/Programs/Microsoft%20VS%20Code/61b3d0ab13/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Mounted expenses router at /api/expenses
Closes #6