### PR TITLE
Add multi-currency conversion with exchange-rate API

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,4 +1,6 @@
 const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api';
+export const SUPPORTED_CURRENCIES = ['CAD', 'USD', 'EUR', 'GBP', 'INR'] as const;
+export type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
 
 export interface AuthUser {
   id: string;
@@ -39,6 +41,9 @@ export interface Expense {
   group_id?: string;
   description: string;
   amount: string;
+  currency: SupportedCurrency;
+  exchange_rate_to_base: string;
+  converted_amount: string;
   note?: string | null;
   receipt_data?: string | null;
   incurred_on: string;
@@ -50,6 +55,7 @@ export interface Expense {
     id: string;
     user_id: string;
     amount_owed: string;
+    converted_amount_owed: string;
     user: AuthUser;
   }>;
 }
@@ -75,6 +81,9 @@ export interface FriendExpense {
   id: string;
   description: string;
   amount: string;
+  currency: SupportedCurrency;
+  exchange_rate_to_base: string;
+  converted_amount: string;
   split_type: 'EQUAL' | 'FULL_AMOUNT';
   activity_type: 'EXPENSE' | 'SETTLEMENT';
   note?: string | null;
@@ -183,6 +192,7 @@ export const api = {
     data: {
       description: string;
       amount: number;
+      currency?: SupportedCurrency;
       paid_by: 'self' | 'friend';
       split_type: 'equal' | 'full_amount';
       note?: string;
@@ -202,6 +212,7 @@ export const api = {
     data: {
       description?: string;
       amount?: number;
+      currency?: SupportedCurrency;
       paid_by?: 'self' | 'friend';
       split_type?: 'equal' | 'full_amount';
       note?: string;
@@ -245,6 +256,7 @@ export const api = {
   addExpense: (data: {
     group_id: string;
     amount: number;
+    currency?: SupportedCurrency;
     description: string;
     note?: string;
     receipt_data?: string;
@@ -262,6 +274,7 @@ export const api = {
     data: {
       description?: string;
       amount?: number;
+      currency?: SupportedCurrency;
       note?: string;
       receipt_data?: string | null;
       incurred_on?: string;

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
-import { api } from '../api';
-import type { Expense, Friend, Group } from '../api';
+import { api, SUPPORTED_CURRENCIES } from '../api';
+import type { Expense, Friend, Group, SupportedCurrency } from '../api';
 import { useAuth } from '../context/useAuth';
 
 type DashboardExpense = Expense & { groupName: string };
@@ -11,6 +11,14 @@ type ChatMessage = {
   role: 'assistant' | 'user';
   text: string;
 };
+
+function formatMoney(amount: number, currency: string) {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
 
 export default function Dashboard() {
   const { token, user, updateUser, logout } = useAuth();
@@ -43,6 +51,7 @@ export default function Dashboard() {
   const [quickExpenseForm, setQuickExpenseForm] = useState({
     description: '',
     amount: '',
+    currency: 'CAD' as SupportedCurrency,
     note: '',
     incurred_on: new Date().toISOString().slice(0, 10),
     receipt_data: '',
@@ -82,6 +91,13 @@ export default function Dashboard() {
       default_currency: user?.default_currency ?? 'CAD',
     });
   }, [user?.default_currency, user?.email, user?.name]);
+
+  useEffect(() => {
+    setQuickExpenseForm((current) => ({
+      ...current,
+      currency: (user?.default_currency as SupportedCurrency | undefined) ?? 'CAD',
+    }));
+  }, [user?.default_currency]);
 
   async function loadDashboard() {
     setIsLoading(true);
@@ -315,6 +331,7 @@ export default function Dashboard() {
     setQuickExpenseForm({
       description: '',
       amount: '',
+      currency: (user?.default_currency as SupportedCurrency | undefined) ?? 'CAD',
       note: '',
       incurred_on: new Date().toISOString().slice(0, 10),
       receipt_data: '',
@@ -372,6 +389,7 @@ export default function Dashboard() {
         await api.addFriendExpense(selectedFriendId, {
           description: quickExpenseForm.description.trim(),
           amount,
+          currency: quickExpenseForm.currency,
           note: quickExpenseForm.note.trim(),
           receipt_data: quickExpenseForm.receipt_data || undefined,
           incurred_on: new Date(`${quickExpenseForm.incurred_on}T12:00:00`).toISOString(),
@@ -392,6 +410,7 @@ export default function Dashboard() {
         group_id: selectedGroupId,
         description: quickExpenseForm.description.trim(),
         amount,
+        currency: quickExpenseForm.currency,
         note: quickExpenseForm.note.trim(),
         receipt_data: quickExpenseForm.receipt_data || undefined,
         incurred_on: new Date(`${quickExpenseForm.incurred_on}T12:00:00`).toISOString(),
@@ -414,12 +433,12 @@ export default function Dashboard() {
         ? 'text-[#ff9630]'
         : 'text-slate-700';
 
-  const dashboardMessage =
+  const dashboardOwedMessage =
     dashboardNetBalance > 0.005
-      ? `Overall, you are owed $${Math.abs(dashboardNetBalance).toFixed(2)}`
+      ? `Overall, you are owed ${formatMoney(Math.abs(dashboardNetBalance), 'CAD')}`
       : dashboardNetBalance < -0.005
-        ? `Overall, you owe $${Math.abs(dashboardNetBalance).toFixed(2)}`
-        : 'Overall, you are settled up';
+        ? `Overall, you owe ${formatMoney(Math.abs(dashboardNetBalance), 'CAD')}`
+        : `Overall, you are settled up in CAD`;
 
   return (
     <div className="space-y-5 pb-6">
@@ -436,7 +455,7 @@ export default function Dashboard() {
               {token ? `Hi, ${user?.name ?? 'there'}` : 'Welcome'}
             </p>
             <h1 className={`mt-2 text-[1.9rem] font-semibold leading-tight ${dashboardTone}`}>
-              {dashboardMessage}
+              {dashboardOwedMessage}
             </h1>
           </div>
           <button
@@ -612,8 +631,13 @@ export default function Dashboard() {
                         {isMe ? 'You added' : `${expense.payer.name} added`} "{expense.description}"
                       </p>
                       <p className="mt-1 text-sm text-[#36b5ac]">
-                        ${Number(expense.amount).toFixed(2)} in {expense.groupName}
+                        {formatMoney(Number(expense.amount), expense.currency)} in {expense.groupName}
                       </p>
+                      {expense.currency !== 'CAD' ? (
+                        <p className="mt-1 text-xs text-slate-400">
+                          Converted: {formatMoney(Number(expense.converted_amount), 'CAD')}
+                        </p>
+                      ) : null}
                       <p className="mt-1 text-xs text-slate-400">
                         {new Date(expense.created_at).toLocaleString()}
                       </p>
@@ -888,6 +912,29 @@ export default function Dashboard() {
                   placeholder="20"
                   className="form-input"
                 />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-medium text-slate-700">Currency</span>
+                <select
+                  value={quickExpenseForm.currency}
+                  onChange={(event) =>
+                    setQuickExpenseForm((current) => ({
+                      ...current,
+                      currency: event.target.value as SupportedCurrency,
+                    }))
+                  }
+                  className="form-input"
+                >
+                  {SUPPORTED_CURRENCIES.map((currency) => (
+                    <option key={currency} value={currency}>
+                      {currency}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-slate-400">
+                  Balances and settlements are normalized to CAD behind the scenes.
+                </p>
               </label>
 
               <label className="block space-y-2">

--- a/client/src/pages/FriendDetail.tsx
+++ b/client/src/pages/FriendDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { api } from '../api';
-import type { FriendExpense, FriendSummary } from '../api';
+import { api, SUPPORTED_CURRENCIES } from '../api';
+import type { FriendExpense, FriendSummary, SupportedCurrency } from '../api';
 import { useAuth } from '../context/useAuth';
 
 type FriendExpenseOption =
@@ -28,6 +28,14 @@ async function readFileAsDataUrl(file: File) {
   });
 }
 
+function formatMoney(amount: number, currency: string) {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
 function getOptionFromExpense(expense: FriendExpense, userId: string | undefined): FriendExpenseOption {
   const paidByMe = expense.payer.id === userId;
 
@@ -49,6 +57,7 @@ export default function FriendDetail() {
   const [form, setForm] = useState({
     description: '',
     amount: '',
+    currency: 'CAD' as SupportedCurrency,
     option: 'you_paid_equal' as FriendExpenseOption,
     note: '',
     incurred_on: new Date().toISOString().slice(0, 10),
@@ -57,6 +66,7 @@ export default function FriendDetail() {
   const [detailForm, setDetailForm] = useState({
     description: '',
     amount: '',
+    currency: 'CAD' as SupportedCurrency,
     option: 'you_paid_equal' as FriendExpenseOption,
     note: '',
     incurred_on: new Date().toISOString().slice(0, 10),
@@ -88,6 +98,7 @@ export default function FriendDetail() {
     setDetailForm({
       description: selectedExpense.description,
       amount: String(Number(selectedExpense.amount).toFixed(2)),
+      currency: selectedExpense.currency,
       option: getOptionFromExpense(selectedExpense, user?.id),
       note: selectedExpense.note ?? '',
       incurred_on: toDateInputValue(selectedExpense.incurred_on),
@@ -95,6 +106,13 @@ export default function FriendDetail() {
     });
     setCommentBody('');
   }, [selectedExpense, user?.id]);
+
+  useEffect(() => {
+    setForm((current) => ({
+      ...current,
+      currency: (user?.default_currency as SupportedCurrency | undefined) ?? 'CAD',
+    }));
+  }, [user?.default_currency]);
 
   const currentBalance = summary?.net_balance ?? 0;
   const balanceTone =
@@ -106,10 +124,10 @@ export default function FriendDetail() {
 
   const balanceMessage =
     currentBalance > 0.005
-      ? `${summary?.friend.name} owes you $${Math.abs(currentBalance).toFixed(2)} overall`
+      ? `${summary?.friend.name} owes you ${formatMoney(Math.abs(currentBalance), 'CAD')} overall`
       : currentBalance < -0.005
-        ? `You owe ${summary?.friend.name} $${Math.abs(currentBalance).toFixed(2)} overall`
-        : `You and ${summary?.friend.name ?? 'your friend'} are settled up`;
+        ? `You owe ${summary?.friend.name} ${formatMoney(Math.abs(currentBalance), 'CAD')} overall`
+        : `You and ${summary?.friend.name ?? 'your friend'} are settled up in CAD`;
 
   const sortedExpenses = useMemo(
     () =>
@@ -173,8 +191,8 @@ export default function FriendDetail() {
     if (expense.activity_type === 'SETTLEMENT') {
       const paidByMe = expense.payer.id === user?.id;
       return paidByMe
-        ? `You settled up with ${summary.friend.name} for $${Number(expense.amount).toFixed(2)}`
-        : `${summary.friend.name} settled up with you for $${Number(expense.amount).toFixed(2)}`;
+        ? `You settled up with ${summary.friend.name} for ${formatMoney(Number(expense.amount), expense.currency)}`
+        : `${summary.friend.name} settled up with you for ${formatMoney(Number(expense.amount), expense.currency)}`;
     }
 
     const amount = Number(expense.amount);
@@ -183,13 +201,13 @@ export default function FriendDetail() {
 
     if (expense.split_type === 'FULL_AMOUNT') {
       return paidByMe
-        ? `${summary.friend.name} owes you $${amount.toFixed(2)}`
-        : `You owe ${summary.friend.name} $${amount.toFixed(2)}`;
+        ? `${summary.friend.name} owes you ${formatMoney(amount, expense.currency)}`
+        : `You owe ${summary.friend.name} ${formatMoney(amount, expense.currency)}`;
     }
 
     return paidByMe
-      ? `${summary.friend.name} owes you $${share.toFixed(2)}`
-      : `You owe ${summary.friend.name} $${share.toFixed(2)}`;
+      ? `${summary.friend.name} owes you ${formatMoney(share, expense.currency)}`
+      : `You owe ${summary.friend.name} ${formatMoney(share, expense.currency)}`;
   }
 
   async function handleReceiptChange(
@@ -239,6 +257,7 @@ export default function FriendDetail() {
       await api.addFriendExpense(friendId, {
         description: form.description.trim(),
         amount,
+        currency: form.currency,
         note: form.note.trim(),
         receipt_data: form.receipt_data || undefined,
         incurred_on: buildIsoDate(form.incurred_on),
@@ -248,6 +267,7 @@ export default function FriendDetail() {
       setForm({
         description: '',
         amount: '',
+        currency: (user?.default_currency as SupportedCurrency | undefined) ?? 'CAD',
         option: 'you_paid_equal',
         note: '',
         incurred_on: new Date().toISOString().slice(0, 10),
@@ -282,6 +302,7 @@ export default function FriendDetail() {
       const updated = await api.updateFriendExpense(friendId, selectedExpense.id, {
         description: detailForm.description.trim(),
         amount,
+        currency: detailForm.currency,
         note: detailForm.note.trim(),
         receipt_data: detailForm.receipt_data || null,
         incurred_on: buildIsoDate(detailForm.incurred_on),
@@ -441,11 +462,11 @@ export default function FriendDetail() {
           <div className="grid grid-cols-3 gap-3">
             <div className="rounded-2xl bg-[#f7f8f4] px-4 py-3">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">You paid</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">${summary.you_paid_total.toFixed(2)}</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">{formatMoney(summary.you_paid_total, 'CAD')}</p>
             </div>
             <div className="rounded-2xl bg-[#f7f8f4] px-4 py-3">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Friend paid</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">${summary.friend_paid_total.toFixed(2)}</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">{formatMoney(summary.friend_paid_total, 'CAD')}</p>
             </div>
             <div className="rounded-2xl bg-[#f7f8f4] px-4 py-3">
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Activities</p>
@@ -516,6 +537,26 @@ export default function FriendDetail() {
                 placeholder="20"
                 className="form-input"
               />
+            </label>
+
+            <label className="block space-y-2">
+              <span className="text-sm font-medium text-slate-700">Currency</span>
+              <select
+                value={form.currency}
+                onChange={(event) =>
+                  setForm((current) => ({
+                    ...current,
+                    currency: event.target.value as SupportedCurrency,
+                  }))
+                }
+                className="form-input"
+              >
+                {SUPPORTED_CURRENCIES.map((currency) => (
+                  <option key={currency} value={currency}>
+                    {currency}
+                  </option>
+                ))}
+              </select>
             </label>
 
             <label className="block space-y-2">
@@ -609,7 +650,16 @@ export default function FriendDetail() {
                     {new Date(expense.incurred_on).toLocaleDateString()}
                   </p>
                 </div>
-                <p className="text-lg font-semibold text-[#36b5ac]">${Number(expense.amount).toFixed(2)}</p>
+                <div className="text-right">
+                  <p className="text-lg font-semibold text-[#36b5ac]">
+                    {formatMoney(Number(expense.amount), expense.currency)}
+                  </p>
+                  {expense.currency !== 'CAD' ? (
+                    <p className="mt-1 text-xs text-slate-400">
+                      {formatMoney(Number(expense.converted_amount), 'CAD')}
+                    </p>
+                  ) : null}
+                </div>
               </div>
               <p className="mt-2 text-sm font-medium text-[#2b938c]">{getExpenseSummary(expense)}</p>
               {expense.note ? <p className="mt-2 text-sm text-slate-500 line-clamp-2">{expense.note}</p> : null}
@@ -644,7 +694,10 @@ export default function FriendDetail() {
               <p className="mt-3 text-lg font-semibold text-slate-900">{selectedExpense.description}</p>
               <p className="mt-1 text-sm text-slate-500">{getExpenseSummary(selectedExpense)}</p>
               <div className="mt-3 grid gap-2 text-sm text-slate-600">
-                <p>Amount: ${Number(selectedExpense.amount).toFixed(2)}</p>
+                <p>Amount: {formatMoney(Number(selectedExpense.amount), selectedExpense.currency)}</p>
+                {selectedExpense.currency !== 'CAD' ? (
+                  <p>Converted amount: {formatMoney(Number(selectedExpense.converted_amount), 'CAD')}</p>
+                ) : null}
                 <p>Occurred on: {new Date(selectedExpense.incurred_on).toLocaleString()}</p>
                 <p>Created: {new Date(selectedExpense.created_at).toLocaleString()}</p>
                 {selectedExpense.updated_at ? (
@@ -665,6 +718,26 @@ export default function FriendDetail() {
                     }
                     className="form-input"
                   />
+                </label>
+
+                <label className="block space-y-2">
+                  <span className="text-sm font-medium text-slate-700">Currency</span>
+                  <select
+                    value={detailForm.currency}
+                    onChange={(event) =>
+                      setDetailForm((current) => ({
+                        ...current,
+                        currency: event.target.value as SupportedCurrency,
+                      }))
+                    }
+                    className="form-input"
+                  >
+                    {SUPPORTED_CURRENCIES.map((currency) => (
+                      <option key={currency} value={currency}>
+                        {currency}
+                      </option>
+                    ))}
+                  </select>
                 </label>
 
                 <label className="block space-y-2">

--- a/client/src/pages/GroupDetail.tsx
+++ b/client/src/pages/GroupDetail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ChangeEvent, FormEvent } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { api } from '../api';
-import type { Balance, Expense, Friend, Group, Settlement } from '../api';
+import { api, SUPPORTED_CURRENCIES } from '../api';
+import type { Balance, Expense, Friend, Group, Settlement, SupportedCurrency } from '../api';
 import { useAuth } from '../context/useAuth';
 
 type ManualSplitEntry = {
@@ -36,6 +36,14 @@ function createManualSplitDraft(group: Group, amount = '') {
   }));
 }
 
+function formatMoney(amount: number, currency: string) {
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
 function inferSplitType(expense: Expense, memberCount: number) {
   const splits = expense.splits ?? [];
 
@@ -66,6 +74,7 @@ export default function GroupDetail() {
   const [expenseForm, setExpenseForm] = useState({
     description: '',
     amount: '',
+    currency: 'CAD' as SupportedCurrency,
     split_type: 'equal' as 'equal' | 'manual',
     manual_splits: [] as ManualSplitEntry[],
     note: '',
@@ -75,6 +84,7 @@ export default function GroupDetail() {
   const [detailForm, setDetailForm] = useState({
     description: '',
     amount: '',
+    currency: 'CAD' as SupportedCurrency,
     split_type: 'equal' as 'equal' | 'manual',
     manual_splits: [] as ManualSplitEntry[],
     note: '',
@@ -133,6 +143,7 @@ export default function GroupDetail() {
     setDetailForm({
       description: selectedExpense.description,
       amount: String(Number(selectedExpense.amount).toFixed(2)),
+      currency: selectedExpense.currency,
       split_type: splitType,
       manual_splits:
         group?.members.map((member) => {
@@ -172,6 +183,13 @@ export default function GroupDetail() {
       };
     });
   }, [group]);
+
+  useEffect(() => {
+    setExpenseForm((current) => ({
+      ...current,
+      currency: (user?.default_currency as SupportedCurrency | undefined) ?? 'CAD',
+    }));
+  }, [user?.default_currency]);
 
   const sortedExpenses = useMemo(
     () =>
@@ -362,6 +380,7 @@ export default function GroupDetail() {
         group_id: groupId,
         description: expenseForm.description.trim(),
         amount,
+        currency: expenseForm.currency,
         note: expenseForm.note.trim(),
         receipt_data: expenseForm.receipt_data || undefined,
         incurred_on: buildIsoDate(expenseForm.incurred_on),
@@ -371,6 +390,7 @@ export default function GroupDetail() {
       setExpenseForm({
         description: '',
         amount: '',
+        currency: (user?.default_currency as SupportedCurrency | undefined) ?? 'CAD',
         split_type: 'equal',
         manual_splits: group ? createManualSplitDraft(group) : [],
         note: '',
@@ -430,6 +450,7 @@ export default function GroupDetail() {
       const updated = await api.updateExpense(selectedExpense.id, {
         description: detailForm.description.trim(),
         amount,
+        currency: detailForm.currency,
         note: detailForm.note.trim(),
         receipt_data: detailForm.receipt_data || null,
         incurred_on: buildIsoDate(detailForm.incurred_on),
@@ -552,7 +573,7 @@ export default function GroupDetail() {
               }`}
             >
               {myBalance > 0 ? '+' : ''}
-              ${Math.abs(myBalance).toFixed(2)}
+              {formatMoney(Math.abs(myBalance), 'CAD')}
             </p>
           </div>
           <div className="soft-card p-4">
@@ -628,6 +649,26 @@ export default function GroupDetail() {
             </label>
 
             <label className="block space-y-2">
+              <span className="text-sm font-medium text-slate-700">Currency</span>
+              <select
+                value={expenseForm.currency}
+                onChange={(event) =>
+                  setExpenseForm((current) => ({
+                    ...current,
+                    currency: event.target.value as SupportedCurrency,
+                  }))
+                }
+                className="form-input"
+              >
+                {SUPPORTED_CURRENCIES.map((currency) => (
+                  <option key={currency} value={currency}>
+                    {currency}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block space-y-2">
               <span className="text-sm font-medium text-slate-700">Expense date</span>
               <input
                 type="date"
@@ -683,7 +724,7 @@ export default function GroupDetail() {
                   ))}
                 </div>
                 <div className="rounded-2xl bg-white px-4 py-3 text-sm text-slate-600">
-                  Manual total: ${manualSplitTotal.toFixed(2)} / ${Number(expenseForm.amount || 0).toFixed(2)}
+                  Manual total: {formatMoney(manualSplitTotal, expenseForm.currency)} / {formatMoney(Number(expenseForm.amount || 0), expenseForm.currency)}
                 </div>
               </div>
             ) : null}
@@ -730,8 +771,8 @@ export default function GroupDetail() {
 
             <div className="rounded-2xl bg-[#eef8f7] px-4 py-3 text-sm text-[#2b938c]">
               {expenseForm.split_type === 'equal'
-                ? `Split preview: ${group.members.length} member(s) would each owe $${splitPreview.toFixed(2)}.`
-                : `Manual preview: total assigned is $${manualSplitTotal.toFixed(2)}.`}
+                ? `Split preview: ${group.members.length} member(s) would each owe ${formatMoney(splitPreview, expenseForm.currency)}.`
+                : `Manual preview: total assigned is ${formatMoney(manualSplitTotal, expenseForm.currency)}.`}
             </div>
             <button type="submit" disabled={isAddingExpense} className="primary-button w-full px-4 py-4">
               {isAddingExpense ? 'Saving expense...' : 'Save expense'}
@@ -840,7 +881,7 @@ export default function GroupDetail() {
                     }`}
                   >
                     {entry.balance > 0 ? '+' : ''}
-                    ${Math.abs(entry.balance).toFixed(2)}
+                    {formatMoney(Math.abs(entry.balance), 'CAD')}
                   </p>
                   <p className="text-xs uppercase tracking-[0.16em] text-slate-400">
                     {Math.abs(entry.balance) < 0.01 ? 'Settled' : entry.balance > 0 ? 'Gets back' : 'Owes'}
@@ -868,7 +909,7 @@ export default function GroupDetail() {
                   <span className="font-semibold text-slate-900">{settlement.from.name}</span> pays{' '}
                   <span className="font-semibold text-slate-900">{settlement.to.name}</span>
                 </p>
-                <p className="mt-2 text-2xl font-semibold text-[#36b5ac]">${settlement.amount.toFixed(2)}</p>
+                <p className="mt-2 text-2xl font-semibold text-[#36b5ac]">{formatMoney(settlement.amount, 'CAD')}</p>
               </div>
             ))}
           </div>
@@ -899,7 +940,16 @@ export default function GroupDetail() {
                       Paid by {expense.payer.name} on {new Date(expense.incurred_on).toLocaleDateString()}
                     </p>
                   </div>
-                  <p className="text-lg font-semibold text-[#36b5ac]">${Number(expense.amount).toFixed(2)}</p>
+                  <div className="text-right">
+                    <p className="text-lg font-semibold text-[#36b5ac]">
+                      {formatMoney(Number(expense.amount), expense.currency)}
+                    </p>
+                    {expense.currency !== 'CAD' ? (
+                      <p className="mt-1 text-xs text-slate-400">
+                        {formatMoney(Number(expense.converted_amount), 'CAD')}
+                      </p>
+                    ) : null}
+                  </div>
                 </div>
 
                 {expense.note ? <p className="mt-2 text-sm text-slate-500 line-clamp-2">{expense.note}</p> : null}
@@ -914,7 +964,7 @@ export default function GroupDetail() {
                         <div key={split.id} className="flex items-center justify-between text-sm">
                           <span className="text-slate-600">{split.user.name}</span>
                           <span className="font-semibold text-slate-900">
-                            ${Number(split.amount_owed).toFixed(2)}
+                            {formatMoney(Number(split.amount_owed), expense.currency)}
                           </span>
                         </div>
                       ))}
@@ -950,7 +1000,10 @@ export default function GroupDetail() {
               <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Summary</p>
               <p className="mt-3 text-lg font-semibold text-slate-900">{selectedExpense.description}</p>
               <div className="mt-3 grid gap-2 text-sm text-slate-600">
-                <p>Amount: ${Number(selectedExpense.amount).toFixed(2)}</p>
+                <p>Amount: {formatMoney(Number(selectedExpense.amount), selectedExpense.currency)}</p>
+                {selectedExpense.currency !== 'CAD' ? (
+                  <p>Converted amount: {formatMoney(Number(selectedExpense.converted_amount), 'CAD')}</p>
+                ) : null}
                 <p>Paid by: {selectedExpense.payer.name}</p>
                 <p>Occurred on: {new Date(selectedExpense.incurred_on).toLocaleString()}</p>
                 <p>Created: {new Date(selectedExpense.created_at).toLocaleString()}</p>
@@ -980,6 +1033,26 @@ export default function GroupDetail() {
                   onChange={(event) => setDetailForm((current) => ({ ...current, amount: event.target.value }))}
                   className="form-input"
                 />
+              </label>
+
+              <label className="block space-y-2">
+                <span className="text-sm font-medium text-slate-700">Currency</span>
+                <select
+                  value={detailForm.currency}
+                  onChange={(event) =>
+                    setDetailForm((current) => ({
+                      ...current,
+                      currency: event.target.value as SupportedCurrency,
+                    }))
+                  }
+                  className="form-input"
+                >
+                  {SUPPORTED_CURRENCIES.map((currency) => (
+                    <option key={currency} value={currency}>
+                      {currency}
+                    </option>
+                  ))}
+                </select>
               </label>
 
               <label className="block space-y-2">
@@ -1070,7 +1143,9 @@ export default function GroupDetail() {
                   {(selectedExpense.splits ?? []).map((split) => (
                     <div key={split.id} className="flex items-center justify-between text-sm">
                       <span className="text-slate-600">{split.user.name}</span>
-                      <span className="font-semibold text-slate-900">${Number(split.amount_owed).toFixed(2)}</span>
+                      <span className="font-semibold text-slate-900">
+                        {formatMoney(Number(split.amount_owed), selectedExpense.currency)}
+                      </span>
                     </div>
                   ))}
                 </div>

--- a/server/.env.example
+++ b/server/.env.example
@@ -11,3 +11,5 @@ SMTP_USER="your-smtp-user"
 SMTP_PASS="your-smtp-password"
 SMTP_FROM="SmartSplit <no-reply@yourdomain.com>"
 SMTP_SECURE="false"
+# Optional template: use {base} where the source currency should go.
+# EXCHANGE_RATE_API_URL="https://open.er-api.com/v6/latest/{base}"

--- a/server/prisma/migrations/06_multi_currency_conversion/migration.sql
+++ b/server/prisma/migrations/06_multi_currency_conversion/migration.sql
@@ -1,0 +1,24 @@
+ALTER TABLE "expenses"
+ADD COLUMN "currency" TEXT NOT NULL DEFAULT 'CAD',
+ADD COLUMN "exchange_rate_to_base" DECIMAL(12,6) NOT NULL DEFAULT 1,
+ADD COLUMN "converted_amount" DECIMAL(10,2) NOT NULL DEFAULT 0;
+
+UPDATE "expenses"
+SET "converted_amount" = "amount"
+WHERE "converted_amount" = 0;
+
+ALTER TABLE "expense_splits"
+ADD COLUMN "converted_amount_owed" DECIMAL(10,2) NOT NULL DEFAULT 0;
+
+UPDATE "expense_splits" es
+SET "converted_amount_owed" = es."amount_owed"
+WHERE es."converted_amount_owed" = 0;
+
+ALTER TABLE "friend_expenses"
+ADD COLUMN "currency" TEXT NOT NULL DEFAULT 'CAD',
+ADD COLUMN "exchange_rate_to_base" DECIMAL(12,6) NOT NULL DEFAULT 1,
+ADD COLUMN "converted_amount" DECIMAL(10,2) NOT NULL DEFAULT 0;
+
+UPDATE "friend_expenses"
+SET "converted_amount" = "amount"
+WHERE "converted_amount" = 0;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -57,6 +57,9 @@ model FriendExpense {
   friendship_id String
   payer_id      String
   amount        Decimal               @db.Decimal(10, 2)
+  currency      String                @default("CAD")
+  exchange_rate_to_base Decimal       @default(1) @db.Decimal(12, 6)
+  converted_amount Decimal            @db.Decimal(10, 2)
   description   String
   split_type    FriendExpenseSplitType
   activity_type FriendActivityType    @default(EXPENSE)
@@ -102,6 +105,9 @@ model Expense {
   group_id     String
   payer_id     String
   amount       Decimal         @db.Decimal(10, 2)
+  currency     String          @default("CAD")
+  exchange_rate_to_base Decimal @default(1) @db.Decimal(12, 6)
+  converted_amount Decimal     @db.Decimal(10, 2)
   description  String
   note         String?
   receipt_data String?
@@ -122,6 +128,7 @@ model ExpenseSplit {
   expense_id  String
   user_id     String
   amount_owed Decimal @db.Decimal(10, 2)
+  converted_amount_owed Decimal @db.Decimal(10, 2)
 
   expense     Expense @relation(fields: [expense_id], references: [id])
   user        User    @relation(fields: [user_id], references: [id])

--- a/server/src/controllers/expenseController.ts
+++ b/server/src/controllers/expenseController.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import { AuthRequest } from "../middleware/auth";
 import prisma from "../utils/prisma";
 import { Prisma } from "@prisma/client";
+import { convertAmountToBase, normalizeCurrency, splitConvertedAmounts } from "../utils/currency";
 
 const expenseInclude = {
   payer: { select: { id: true, name: true, email: true, default_currency: true } },
@@ -85,15 +86,26 @@ function buildManualSplitRows(
 
 function buildSplitRows(
   total: Prisma.Decimal,
+  convertedTotal: Prisma.Decimal,
   userIds: string[],
   splitType: "equal" | "manual",
   rawSplits: Array<{ user_id: string; amount_owed: number | string }> = [],
 ) {
-  if (splitType === "manual") {
-    return buildManualSplitRows(total, userIds, rawSplits);
-  }
+  const originalRows =
+    splitType === "manual"
+      ? buildManualSplitRows(total, userIds, rawSplits)
+      : buildEqualSplitRows(total, userIds);
 
-  return buildEqualSplitRows(total, userIds);
+  const weights =
+    splitType === "manual"
+      ? originalRows.map((split) => Number(split.amount_owed))
+      : originalRows.map(() => 1);
+  const convertedShares = splitConvertedAmounts(Number(convertedTotal), weights);
+
+  return originalRows.map((split, index) => ({
+    ...split,
+    converted_amount_owed: new Prisma.Decimal(convertedShares[index]).toDecimalPlaces(2),
+  }));
 }
 
 // POST /api/expenses
@@ -108,6 +120,7 @@ export const addExpense = async (
     note,
     receipt_data,
     incurred_on,
+    currency,
     split_type,
     splits,
   } = req.body;
@@ -133,8 +146,11 @@ export const addExpense = async (
 
     const members = await prisma.groupMember.findMany({ where: { group_id } });
     const total = new Prisma.Decimal(amount);
+    const converted = await convertAmountToBase(Number(amount), currency);
+    const convertedTotal = new Prisma.Decimal(converted.convertedAmount);
     const splitRows = buildSplitRows(
       total,
+      convertedTotal,
       members.map((member) => member.user_id),
       split_type === "manual" ? "manual" : "equal",
       Array.isArray(splits) ? splits : [],
@@ -146,6 +162,9 @@ export const addExpense = async (
           group_id,
           payer_id: payerId,
           amount: total,
+          currency: converted.currency,
+          exchange_rate_to_base: new Prisma.Decimal(converted.exchangeRateToBase),
+          converted_amount: convertedTotal,
           description: String(description).trim(),
           note: String(note ?? "").trim() || null,
           receipt_data: String(receipt_data ?? "").trim() || null,
@@ -158,6 +177,7 @@ export const addExpense = async (
           expense_id: newExpense.id,
           user_id: split.user_id,
           amount_owed: split.amount_owed,
+          converted_amount_owed: split.converted_amount_owed,
         })),
       });
 
@@ -170,7 +190,12 @@ export const addExpense = async (
     res.status(201).json(expense);
   } catch (error) {
     console.error("Add expense error:", error);
-    if (error instanceof Error && error.message.toLowerCase().includes("split")) {
+    if (
+      error instanceof Error &&
+      (error.message.toLowerCase().includes("split") ||
+        error.message.toLowerCase().includes("currency") ||
+        error.message.toLowerCase().includes("amount"))
+    ) {
       res.status(400).json({ error: error.message });
       return;
     }
@@ -245,7 +270,7 @@ export const updateExpense = async (
 ): Promise<void> => {
   const userId = req.userId!;
   const expenseId = req.params.expenseId as string;
-  const { description, amount, note, receipt_data, incurred_on, split_type, splits } = req.body;
+  const { description, amount, note, receipt_data, incurred_on, currency, split_type, splits } = req.body;
 
   try {
     const existing = await prisma.expense.findUnique({
@@ -274,8 +299,15 @@ export const updateExpense = async (
       Number.isFinite(numericAmount) && numericAmount > 0
         ? new Prisma.Decimal(numericAmount)
         : existing.amount;
+    const nextCurrency =
+      currency === undefined
+        ? existing.currency
+        : normalizeCurrency(currency);
+    const converted = await convertAmountToBase(Number(nextAmount), nextCurrency);
+    const convertedTotal = new Prisma.Decimal(converted.convertedAmount);
     const splitRows = buildSplitRows(
       nextAmount,
+      convertedTotal,
       members.map((member) => member.user_id),
       split_type === "manual" ? "manual" : "equal",
       Array.isArray(splits) ? splits : [],
@@ -287,6 +319,9 @@ export const updateExpense = async (
         data: {
           description: String(description ?? existing.description).trim(),
           amount: nextAmount,
+          currency: converted.currency,
+          exchange_rate_to_base: new Prisma.Decimal(converted.exchangeRateToBase),
+          converted_amount: convertedTotal,
           note: note === undefined ? existing.note : String(note).trim() || null,
           receipt_data:
             receipt_data === undefined
@@ -302,6 +337,7 @@ export const updateExpense = async (
           expense_id: expenseId,
           user_id: split.user_id,
           amount_owed: split.amount_owed,
+          converted_amount_owed: split.converted_amount_owed,
         })),
       });
 
@@ -314,7 +350,12 @@ export const updateExpense = async (
     res.json(expense);
   } catch (error) {
     console.error("Update expense error:", error);
-    if (error instanceof Error && error.message.toLowerCase().includes("split")) {
+    if (
+      error instanceof Error &&
+      (error.message.toLowerCase().includes("split") ||
+        error.message.toLowerCase().includes("currency") ||
+        error.message.toLowerCase().includes("amount"))
+    ) {
       res.status(400).json({ error: error.message });
       return;
     }

--- a/server/src/controllers/friendExpenseController.ts
+++ b/server/src/controllers/friendExpenseController.ts
@@ -2,6 +2,7 @@ import { Response } from "express";
 import { Prisma } from "@prisma/client";
 import prisma from "../utils/prisma";
 import { AuthRequest } from "../middleware/auth";
+import { convertAmountToBase, normalizeCurrency } from "../utils/currency";
 
 function toPair(userId: string, friendId: string) {
   return userId < friendId
@@ -32,6 +33,7 @@ async function getFriendshipOrNull(userId: string, friendId: string) {
 function getFriendSummaryNumbers(
   activities: Array<{
     amount: Prisma.Decimal | number;
+    converted_amount: Prisma.Decimal | number;
     split_type: "EQUAL" | "FULL_AMOUNT";
     activity_type: "EXPENSE" | "SETTLEMENT";
     payer: { id: string };
@@ -44,14 +46,15 @@ function getFriendSummaryNumbers(
 
   activities.forEach((activity) => {
     const amount = Number(activity.amount);
+    const convertedAmount = Number(activity.converted_amount);
     const paidByMe = activity.payer.id === userId;
 
     if (activity.activity_type === "SETTLEMENT") {
-      netBalance += paidByMe ? -amount : amount;
+      netBalance += paidByMe ? -convertedAmount : convertedAmount;
       return;
     }
 
-    const impact = activity.split_type === "FULL_AMOUNT" ? amount : amount / 2;
+    const impact = activity.split_type === "FULL_AMOUNT" ? convertedAmount : convertedAmount / 2;
 
     if (paidByMe) {
       youPaidTotal += amount;
@@ -176,6 +179,7 @@ export const addFriendExpense = async (
   const {
     description,
     amount,
+    currency,
     paid_by,
     split_type,
     note,
@@ -184,6 +188,7 @@ export const addFriendExpense = async (
   }: {
     description?: string;
     amount?: number;
+    currency?: string;
     paid_by?: "self" | "friend";
     split_type?: "equal" | "full_amount";
     note?: string;
@@ -207,12 +212,16 @@ export const addFriendExpense = async (
     }
 
     const payerId = paid_by === "self" ? userId : friendId;
+    const converted = await convertAmountToBase(amount, currency);
 
     const expense = await prisma.friendExpense.create({
       data: {
         friendship_id: friendship.id,
         payer_id: payerId,
         amount: new Prisma.Decimal(amount),
+        currency: converted.currency,
+        exchange_rate_to_base: new Prisma.Decimal(converted.exchangeRateToBase),
+        converted_amount: new Prisma.Decimal(converted.convertedAmount),
         description: description.trim(),
         split_type: split_type === "equal" ? "EQUAL" : "FULL_AMOUNT",
         note: note?.trim() || null,
@@ -239,6 +248,7 @@ export const updateFriendExpense = async (
   const {
     description,
     amount,
+    currency,
     paid_by,
     split_type,
     note,
@@ -247,6 +257,7 @@ export const updateFriendExpense = async (
   } = req.body as {
     description?: string;
     amount?: number;
+    currency?: string;
     paid_by?: "self" | "friend";
     split_type?: "equal" | "full_amount";
     note?: string;
@@ -271,14 +282,20 @@ export const updateFriendExpense = async (
       return;
     }
 
+    const nextAmount =
+      typeof amount === "number" && amount > 0 ? amount : Number(existing.amount);
+    const nextCurrency =
+      currency === undefined ? existing.currency : normalizeCurrency(currency);
+    const converted = await convertAmountToBase(nextAmount, nextCurrency);
+
     const expense = await prisma.friendExpense.update({
       where: { id: expenseId },
       data: {
         description: description?.trim() || existing.description,
-        amount:
-          typeof amount === "number" && amount > 0
-            ? new Prisma.Decimal(amount)
-            : existing.amount,
+        amount: new Prisma.Decimal(nextAmount),
+        currency: converted.currency,
+        exchange_rate_to_base: new Prisma.Decimal(converted.exchangeRateToBase),
+        converted_amount: new Prisma.Decimal(converted.convertedAmount),
         payer_id:
           paid_by === "self"
             ? userId
@@ -422,6 +439,9 @@ export const settleUpFriend = async (
         friendship_id: friendship.id,
         payer_id: payerId,
         amount: new Prisma.Decimal(Math.abs(summary.netBalance)),
+        currency: "CAD",
+        exchange_rate_to_base: new Prisma.Decimal(1),
+        converted_amount: new Prisma.Decimal(Math.abs(summary.netBalance)),
         description: "Settle up",
         split_type: "FULL_AMOUNT",
         activity_type: "SETTLEMENT",

--- a/server/src/controllers/settlementController.ts
+++ b/server/src/controllers/settlementController.ts
@@ -42,12 +42,12 @@ export const getBalances = async (
     for (const expense of expenses) {
       // Add what the payer paid
       const current = balanceMap.get(expense.payer_id) ?? 0;
-      balanceMap.set(expense.payer_id, current + Number(expense.amount));
+      balanceMap.set(expense.payer_id, current + Number(expense.converted_amount));
 
       // Subtract what each person owes
       for (const split of expense.splits) {
         const owed = balanceMap.get(split.user_id) ?? 0;
-        balanceMap.set(split.user_id, owed - Number(split.amount_owed));
+        balanceMap.set(split.user_id, owed - Number(split.converted_amount_owed));
       }
     }
 
@@ -101,11 +101,11 @@ export const getSettlements = async (
 
     for (const expense of expenses) {
       const current = balanceMap.get(expense.payer_id) ?? 0;
-      balanceMap.set(expense.payer_id, current + Number(expense.amount));
+      balanceMap.set(expense.payer_id, current + Number(expense.converted_amount));
 
       for (const split of expense.splits) {
         const owed = balanceMap.get(split.user_id) ?? 0;
-        balanceMap.set(split.user_id, owed - Number(split.amount_owed));
+        balanceMap.set(split.user_id, owed - Number(split.converted_amount_owed));
       }
     }
 

--- a/server/src/utils/currency.ts
+++ b/server/src/utils/currency.ts
@@ -1,0 +1,133 @@
+const BASE_CURRENCY = "CAD";
+const SUPPORTED_CURRENCIES = ["CAD", "USD", "EUR", "GBP", "INR"] as const;
+
+type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+type RateResponse = {
+  result?: string;
+  rates?: Record<string, number>;
+};
+
+const rateCache = new Map<string, { expiresAt: number; rates: Record<string, number> }>();
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+function normalizeCurrency(value: string | undefined | null): SupportedCurrency {
+  const normalized = String(value ?? BASE_CURRENCY).trim().toUpperCase();
+  if (SUPPORTED_CURRENCIES.includes(normalized as SupportedCurrency)) {
+    return normalized as SupportedCurrency;
+  }
+
+  throw new Error(`Unsupported currency: ${normalized}`);
+}
+
+function buildRatesUrl(baseCurrency: SupportedCurrency) {
+  const customUrl = process.env.EXCHANGE_RATE_API_URL?.trim();
+
+  if (customUrl) {
+    return customUrl.replace("{base}", encodeURIComponent(baseCurrency));
+  }
+
+  return `https://open.er-api.com/v6/latest/${encodeURIComponent(baseCurrency)}`;
+}
+
+async function loadRates(baseCurrency: SupportedCurrency) {
+  if (baseCurrency === BASE_CURRENCY) {
+    return { [BASE_CURRENCY]: 1 };
+  }
+
+  const cached = rateCache.get(baseCurrency);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.rates;
+  }
+
+  const response = await fetch(buildRatesUrl(baseCurrency));
+
+  if (!response.ok) {
+    throw new Error(`Exchange-rate API request failed (${response.status})`);
+  }
+
+  const body = (await response.json()) as RateResponse;
+  if (!body.rates || typeof body.rates[BASE_CURRENCY] !== "number") {
+    throw new Error("Exchange-rate API did not return a usable CAD rate");
+  }
+
+  rateCache.set(baseCurrency, {
+    expiresAt: Date.now() + CACHE_TTL_MS,
+    rates: body.rates,
+  });
+
+  return body.rates;
+}
+
+export async function convertAmountToBase(
+  amount: number,
+  sourceCurrencyInput: string | undefined | null,
+) {
+  const sourceCurrency = normalizeCurrency(sourceCurrencyInput);
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error("Amount must be greater than zero");
+  }
+
+  if (sourceCurrency === BASE_CURRENCY) {
+    return {
+      currency: sourceCurrency,
+      exchangeRateToBase: 1,
+      convertedAmount: Number(amount.toFixed(2)),
+    };
+  }
+
+  const rates = await loadRates(sourceCurrency);
+  const exchangeRateToBase = rates[BASE_CURRENCY];
+
+  if (typeof exchangeRateToBase !== "number" || exchangeRateToBase <= 0) {
+    throw new Error(`Unable to convert ${sourceCurrency} to ${BASE_CURRENCY}`);
+  }
+
+  return {
+    currency: sourceCurrency,
+    exchangeRateToBase,
+    convertedAmount: Number((amount * exchangeRateToBase).toFixed(2)),
+  };
+}
+
+export function convertAmountFromBase(
+  amountInBase: number,
+  targetCurrencyInput: string | undefined | null,
+  exchangeRateToBase: number | undefined | null,
+) {
+  const targetCurrency = normalizeCurrency(targetCurrencyInput);
+  const rate = Number(exchangeRateToBase ?? 1);
+
+  if (targetCurrency === BASE_CURRENCY || !Number.isFinite(rate) || rate <= 0) {
+    return Number(amountInBase.toFixed(2));
+  }
+
+  return Number((amountInBase / rate).toFixed(2));
+}
+
+export function splitConvertedAmounts(totalConvertedAmount: number, weights: number[]) {
+  const totalCents = Math.round(totalConvertedAmount * 100);
+  const totalWeight = weights.reduce((sum, value) => sum + value, 0);
+
+  if (totalWeight <= 0) {
+    return weights.map(() => 0);
+  }
+
+  const rawShares = weights.map((value) => (totalCents * value) / totalWeight);
+  const baseShares = rawShares.map((value) => Math.floor(value));
+  let remainder = totalCents - baseShares.reduce((sum, value) => sum + value, 0);
+
+  const ranked = rawShares
+    .map((value, index) => ({ index, fraction: value - Math.floor(value) }))
+    .sort((a, b) => b.fraction - a.fraction);
+
+  for (let i = 0; i < ranked.length && remainder > 0; i += 1) {
+    baseShares[ranked[i].index] += 1;
+    remainder -= 1;
+  }
+
+  return baseShares.map((value) => value / 100);
+}
+
+export { BASE_CURRENCY, SUPPORTED_CURRENCIES, normalizeCurrency };


### PR DESCRIPTION
Closes #61

## What I changed
- added real multi-currency conversion support for group and friend expenses
- added currency, exchange rate, and converted CAD amount storage for expenses
- added converted CAD split amounts for group expense splits
- updated balances and settlements to use normalized CAD values
- added currency selectors to friend, group, and quick-add expense flows
- updated expense/activity/detail views to show original currency and converted CAD values where useful
- added configurable exchange-rate service support with an optional env var template

## Files updated
- `server/prisma/schema.prisma`
- `server/prisma/migrations/06_multi_currency_conversion/migration.sql`
- `server/src/utils/currency.ts`
- `server/src/controllers/expenseController.ts`
- `server/src/controllers/friendExpenseController.ts`
- `server/src/controllers/settlementController.ts`
- `server/.env.example`
- `client/src/api.ts`
- `client/src/pages/Dashboard.tsx`
- `client/src/pages/FriendDetail.tsx`
- `client/src/pages/GroupDetail.tsx`

## Testing
- `client`: `npm.cmd install`
- `server`: `npm.cmd install`
- `server`: `npm.cmd run build`
- `client`: `npm.cmd run build`
- `server`: `npx.cmd prisma migrate deploy`

## Result
Users can now create expenses in supported currencies (`CAD`, `USD`, `EUR`, `GBP`, `INR`) while the app stores normalized CAD values for accurate balances and settlement calculations. Existing friend, group, equal split, manual split, receipt, note, and comment features continue to work.
