### PR TITLE
receipts: add external storage integration

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -13,3 +13,7 @@ SMTP_FROM="SmartSplit <no-reply@yourdomain.com>"
 SMTP_SECURE="false"
 # Optional template: use {base} where the source currency should go.
 # EXCHANGE_RATE_API_URL="https://open.er-api.com/v6/latest/{base}"
+CLOUDINARY_CLOUD_NAME="your-cloud-name"
+CLOUDINARY_API_KEY="your-cloudinary-api-key"
+CLOUDINARY_API_SECRET="your-cloudinary-api-secret"
+CLOUDINARY_FOLDER="smartsplit/receipts"

--- a/server/prisma/migrations/07_receipt_storage_keys/migration.sql
+++ b/server/prisma/migrations/07_receipt_storage_keys/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "expenses"
+ADD COLUMN "receipt_storage_key" TEXT;
+
+ALTER TABLE "friend_expenses"
+ADD COLUMN "receipt_storage_key" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -65,6 +65,7 @@ model FriendExpense {
   activity_type FriendActivityType    @default(EXPENSE)
   note          String?
   receipt_data  String?
+  receipt_storage_key String?
   incurred_on   DateTime              @default(now())
   created_at    DateTime              @default(now())
   updated_at    DateTime              @updatedAt
@@ -111,6 +112,7 @@ model Expense {
   description  String
   note         String?
   receipt_data String?
+  receipt_storage_key String?
   incurred_on  DateTime        @default(now())
   created_at   DateTime        @default(now())
   updated_at   DateTime        @updatedAt

--- a/server/src/controllers/expenseController.ts
+++ b/server/src/controllers/expenseController.ts
@@ -3,6 +3,7 @@ import { AuthRequest } from "../middleware/auth";
 import prisma from "../utils/prisma";
 import { Prisma } from "@prisma/client";
 import { convertAmountToBase, normalizeCurrency, splitConvertedAmounts } from "../utils/currency";
+import { deleteStoredReceipt, resolveStoredReceipt } from "../utils/receiptStorage";
 
 const expenseInclude = {
   payer: { select: { id: true, name: true, email: true, default_currency: true } },
@@ -148,6 +149,7 @@ export const addExpense = async (
     const total = new Prisma.Decimal(amount);
     const converted = await convertAmountToBase(Number(amount), currency);
     const convertedTotal = new Prisma.Decimal(converted.convertedAmount);
+    const storedReceipt = await resolveStoredReceipt(receipt_data, null, null);
     const splitRows = buildSplitRows(
       total,
       convertedTotal,
@@ -167,7 +169,8 @@ export const addExpense = async (
           converted_amount: convertedTotal,
           description: String(description).trim(),
           note: String(note ?? "").trim() || null,
-          receipt_data: String(receipt_data ?? "").trim() || null,
+          receipt_data: storedReceipt.url,
+          receipt_storage_key: storedReceipt.storageKey,
           incurred_on: incurred_on ? new Date(incurred_on) : new Date(),
         },
       });
@@ -305,6 +308,11 @@ export const updateExpense = async (
         : normalizeCurrency(currency);
     const converted = await convertAmountToBase(Number(nextAmount), nextCurrency);
     const convertedTotal = new Prisma.Decimal(converted.convertedAmount);
+    const storedReceipt = await resolveStoredReceipt(
+      receipt_data,
+      existing.receipt_data,
+      existing.receipt_storage_key,
+    );
     const splitRows = buildSplitRows(
       nextAmount,
       convertedTotal,
@@ -323,10 +331,8 @@ export const updateExpense = async (
           exchange_rate_to_base: new Prisma.Decimal(converted.exchangeRateToBase),
           converted_amount: convertedTotal,
           note: note === undefined ? existing.note : String(note).trim() || null,
-          receipt_data:
-            receipt_data === undefined
-              ? existing.receipt_data
-              : String(receipt_data).trim() || null,
+          receipt_data: storedReceipt.url,
+          receipt_storage_key: storedReceipt.storageKey,
           incurred_on: incurred_on ? new Date(incurred_on) : existing.incurred_on,
         },
       });
@@ -373,7 +379,7 @@ export const deleteExpense = async (
   try {
     const existing = await prisma.expense.findUnique({
       where: { id: expenseId },
-      select: { id: true, group_id: true },
+      select: { id: true, group_id: true, receipt_storage_key: true },
     });
 
     if (!existing) {
@@ -393,6 +399,7 @@ export const deleteExpense = async (
       prisma.expenseComment.deleteMany({ where: { expense_id: expenseId } }),
       prisma.expense.delete({ where: { id: expenseId } }),
     ]);
+    await deleteStoredReceipt(existing.receipt_storage_key);
 
     res.json({ message: "Expense deleted" });
   } catch (error) {

--- a/server/src/controllers/friendExpenseController.ts
+++ b/server/src/controllers/friendExpenseController.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import prisma from "../utils/prisma";
 import { AuthRequest } from "../middleware/auth";
 import { convertAmountToBase, normalizeCurrency } from "../utils/currency";
+import { deleteStoredReceipt, resolveStoredReceipt } from "../utils/receiptStorage";
 
 function toPair(userId: string, friendId: string) {
   return userId < friendId
@@ -213,6 +214,7 @@ export const addFriendExpense = async (
 
     const payerId = paid_by === "self" ? userId : friendId;
     const converted = await convertAmountToBase(amount, currency);
+    const storedReceipt = await resolveStoredReceipt(receipt_data, null, null);
 
     const expense = await prisma.friendExpense.create({
       data: {
@@ -225,7 +227,8 @@ export const addFriendExpense = async (
         description: description.trim(),
         split_type: split_type === "equal" ? "EQUAL" : "FULL_AMOUNT",
         note: note?.trim() || null,
-        receipt_data: receipt_data?.trim() || null,
+        receipt_data: storedReceipt.url,
+        receipt_storage_key: storedReceipt.storageKey,
         incurred_on: incurred_on ? new Date(incurred_on) : new Date(),
       },
       include: friendExpenseInclude,
@@ -287,6 +290,11 @@ export const updateFriendExpense = async (
     const nextCurrency =
       currency === undefined ? existing.currency : normalizeCurrency(currency);
     const converted = await convertAmountToBase(nextAmount, nextCurrency);
+    const storedReceipt = await resolveStoredReceipt(
+      receipt_data,
+      existing.receipt_data,
+      existing.receipt_storage_key,
+    );
 
     const expense = await prisma.friendExpense.update({
       where: { id: expenseId },
@@ -309,10 +317,8 @@ export const updateFriendExpense = async (
               ? "FULL_AMOUNT"
               : existing.split_type,
         note: note === undefined ? existing.note : note?.trim() || null,
-        receipt_data:
-          receipt_data === undefined
-            ? existing.receipt_data
-            : receipt_data?.trim() || null,
+        receipt_data: storedReceipt.url,
+        receipt_storage_key: storedReceipt.storageKey,
         incurred_on: incurred_on ? new Date(incurred_on) : existing.incurred_on,
       },
       include: friendExpenseInclude,
@@ -343,7 +349,7 @@ export const deleteFriendExpense = async (
 
     const existing = await prisma.friendExpense.findFirst({
       where: { id: expenseId, friendship_id: friendship.id },
-      select: { id: true },
+      select: { id: true, receipt_storage_key: true },
     });
 
     if (!existing) {
@@ -352,6 +358,7 @@ export const deleteFriendExpense = async (
     }
 
     await prisma.friendExpense.delete({ where: { id: expenseId } });
+    await deleteStoredReceipt(existing.receipt_storage_key);
     res.json({ message: "Friend expense deleted" });
   } catch (error) {
     console.error("Delete friend expense error:", error);

--- a/server/src/utils/receiptStorage.ts
+++ b/server/src/utils/receiptStorage.ts
@@ -1,0 +1,165 @@
+import { createHash } from "crypto";
+
+type StoredReceipt = {
+  url: string | null;
+  storageKey: string | null;
+};
+
+function isDataUrl(value: string | null | undefined) {
+  return typeof value === "string" && value.startsWith("data:image/");
+}
+
+function isRemoteUrl(value: string | null | undefined) {
+  return typeof value === "string" && /^https?:\/\//i.test(value);
+}
+
+function getCloudinaryConfig() {
+  const cloudName = process.env.CLOUDINARY_CLOUD_NAME?.trim();
+  const apiKey = process.env.CLOUDINARY_API_KEY?.trim();
+  const apiSecret = process.env.CLOUDINARY_API_SECRET?.trim();
+  const folder = process.env.CLOUDINARY_FOLDER?.trim() || "smartsplit/receipts";
+
+  if (!cloudName || !apiKey || !apiSecret) {
+    return null;
+  }
+
+  return { cloudName, apiKey, apiSecret, folder };
+}
+
+function signParams(params: Record<string, string>, apiSecret: string) {
+  const serialized = Object.entries(params)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+
+  return createHash("sha1").update(`${serialized}${apiSecret}`).digest("hex");
+}
+
+async function uploadReceiptDataUrl(dataUrl: string) {
+  const config = getCloudinaryConfig();
+
+  if (!config) {
+    throw new Error(
+      "Receipt upload is not configured. Add CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, and CLOUDINARY_API_SECRET.",
+    );
+  }
+
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = signParams(
+    {
+      folder: config.folder,
+      timestamp,
+    },
+    config.apiSecret,
+  );
+
+  const form = new FormData();
+  form.append("file", dataUrl);
+  form.append("folder", config.folder);
+  form.append("api_key", config.apiKey);
+  form.append("timestamp", timestamp);
+  form.append("signature", signature);
+
+  const response = await fetch(
+    `https://api.cloudinary.com/v1_1/${encodeURIComponent(config.cloudName)}/image/upload`,
+    {
+      method: "POST",
+      body: form,
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Receipt upload failed (${response.status}): ${body}`);
+  }
+
+  const body = (await response.json()) as { secure_url?: string; public_id?: string };
+
+  if (!body.secure_url || !body.public_id) {
+    throw new Error("Receipt upload did not return a usable URL");
+  }
+
+  return {
+    url: body.secure_url,
+    storageKey: body.public_id,
+  };
+}
+
+export async function deleteStoredReceipt(storageKey: string | null | undefined) {
+  if (!storageKey) {
+    return;
+  }
+
+  const config = getCloudinaryConfig();
+  if (!config) {
+    return;
+  }
+
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const signature = signParams(
+    {
+      public_id: storageKey,
+      timestamp,
+    },
+    config.apiSecret,
+  );
+
+  const form = new FormData();
+  form.append("public_id", storageKey);
+  form.append("api_key", config.apiKey);
+  form.append("timestamp", timestamp);
+  form.append("signature", signature);
+
+  const response = await fetch(
+    `https://api.cloudinary.com/v1_1/${encodeURIComponent(config.cloudName)}/image/destroy`,
+    {
+      method: "POST",
+      body: form,
+    },
+  );
+
+  if (!response.ok) {
+    console.warn(`Receipt deletion failed for ${storageKey} with status ${response.status}`);
+  }
+}
+
+export async function resolveStoredReceipt(
+  incomingReceipt: string | null | undefined,
+  existingReceiptUrl: string | null | undefined,
+  existingStorageKey: string | null | undefined,
+): Promise<StoredReceipt> {
+  if (incomingReceipt === undefined) {
+    return {
+      url: existingReceiptUrl ?? null,
+      storageKey: existingStorageKey ?? null,
+    };
+  }
+
+  const normalized = String(incomingReceipt ?? "").trim();
+
+  if (!normalized) {
+    await deleteStoredReceipt(existingStorageKey);
+    return {
+      url: null,
+      storageKey: null,
+    };
+  }
+
+  if (isRemoteUrl(normalized)) {
+    return {
+      url: normalized,
+      storageKey: existingStorageKey ?? null,
+    };
+  }
+
+  if (!isDataUrl(normalized)) {
+    throw new Error("Receipt must be an image upload or a hosted receipt URL");
+  }
+
+  const uploaded = await uploadReceiptDataUrl(normalized);
+  if (existingStorageKey && existingStorageKey !== uploaded.storageKey) {
+    await deleteStoredReceipt(existingStorageKey);
+  }
+
+  return uploaded;
+}


### PR DESCRIPTION
Closes #63

## What I changed
- upgraded receipt handling from inline image data to external storage-backed uploads
- added receipt storage key fields for group and friend expenses
- added backend Cloudinary upload/delete utility
- updated group expense create/update/delete flows to store hosted receipt URLs and clean up old files
- updated friend expense create/update/delete flows to store hosted receipt URLs and clean up old files
- added Cloudinary configuration variables to the server env example

## Files updated
- `server/prisma/schema.prisma`
- `server/prisma/migrations/07_receipt_storage_keys/migration.sql`
- `server/src/utils/receiptStorage.ts`
- `server/src/controllers/expenseController.ts`
- `server/src/controllers/friendExpenseController.ts`
- `server/.env.example`

## Testing
- `server`: `npm.cmd run build`
- `client`: `npm.cmd run build`
- `server`: `npx.cmd prisma migrate deploy`

## Result
Receipt images are now prepared to be stored in external storage instead of remaining inline in expense data. Existing friend and group expense flows continue to work, while receipt previews now rely on hosted URLs and old stored files can be cleaned up on update/delete.
