### PR TITLE
Restore desktop page visibility without breaking app shell layout

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -273,22 +273,14 @@ select {
 }
 
 @media (min-width: 1024px) {
-  html,
-  body,
-  #root {
-    height: 100%;
-    overflow: hidden;
-  }
-
   .app-shell {
-    height: 100vh;
+    min-height: 100vh;
     padding: 1.25rem;
-    overflow: hidden;
   }
 
   .mobile-shell {
-    height: calc(100vh - 2.5rem);
-    min-height: 0;
+    min-height: calc(100vh - 2.5rem);
+    max-height: calc(100vh - 2.5rem);
     border: 1px solid rgba(214, 215, 210, 0.78);
     border-radius: 2rem;
     box-shadow: 0 24px 70px rgba(31, 41, 55, 0.08);

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 
 export default function Home() {
   return (
-    <div className="px-4 py-6 md:px-6 md:py-8 lg:min-h-screen lg:overflow-hidden">
+    <div className="px-4 py-6 md:px-6 md:py-8 lg:min-h-screen">
       <div className="mx-auto grid w-full max-w-6xl gap-6 lg:min-h-[calc(100vh-4rem)] lg:grid-cols-[minmax(0,1.1fr)_minmax(22rem,26rem)]">
         <section className="flex flex-col justify-between rounded-[2rem] border border-[#d6d7d2]/80 bg-[linear-gradient(145deg,rgba(255,255,255,0.98),rgba(241,248,247,0.92))] px-6 py-8 shadow-[0_18px_55px_rgba(31,41,55,0.08)] md:px-8 md:py-10">
           <div>


### PR DESCRIPTION
## What I changed
- removed the global desktop overflow lock that was clipping public pages like login and register
- kept the desktop shell containment behavior scoped to the authenticated app layout
- adjusted the desktop shell sizing to use safer min/max height handling
- removed extra desktop overflow clipping from the home page

## Files updated
- `client/src/index.css`
- `client/src/pages/Home.tsx`

## Testing
- `client`: `npm.cmd run lint`
- `client`: `npm.cmd run build`
- `server`: `npm.cmd run build`

## Result
Public pages are visible again on desktop, while the logged-in app still keeps the cleaner contained desktop shell layout.
